### PR TITLE
feature: 历史记录过期时间与以群为单位的插嘴概率

### DIFF
--- a/header.txt
+++ b/header.txt
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         AI 插嘴
 // @author       MintCider
-// @version      0.2.0
+// @version      0.3.0
 // @description  接入 AI 并随机插嘴。详细使用说明见项目主页 README。
 // @timestamp    1726221700
 // @license      MIT
@@ -19,3 +19,14 @@
 // ## 功能
 //
 // - `.interrupt clear` 命令增加 `all/users/assistant` 参数。可以在保留用户聊天记录的情况下，删除骰子 AI 生成的回复，以快速应用 system prompt 的变化。
+
+// # v0.3.0 更新日志
+//
+// ## ⚠️注意⚠️
+//
+// 由于数据存储格式发生变动，从 `v0.3.0` 之前版本升级而来的话，会出现数据不匹配。可以通过 `.interrupt clear all` 清除旧数据。
+//
+// ## 功能
+//
+//- 在配置里增加了缓存历史记录的过期时间（秒），过期后会自动清除，如果为0则不会过期。
+//- 增加指令：interrupt on <群插嘴概率>，与全局配置的概率取最小值，interrupt on仍可以作为应用全局配置概率的命令使用。


### PR DESCRIPTION
- 在配置里增加了缓存历史记录的过期时间（秒），过期后会自动清除，如果为0则不会过期。
- 增加指令：interrupt on <群插嘴概率>，与全局配置的概率取最小值，interrupt on仍可以作为应用全局配置概率的命令使用。